### PR TITLE
Remove deadlock of 500s after transmit error

### DIFF
--- a/src/lib/adapter/RPi/RPiCECAdapterMessageQueue.cpp
+++ b/src/lib/adapter/RPi/RPiCECAdapterMessageQueue.cpp
@@ -218,7 +218,7 @@ cec_adapter_message_state CRPiCECAdapterMessageQueue::Write(const cec_command &c
       {
         bRetry = true;
         LIB_CEC->AddLog(CEC_LOG_DEBUG, "command '%s' timeout", command.opcode_set ? CCECTypeUtils::ToString(command.opcode) : "POLL");
-        sleep(CEC_DEFAULT_TRANSMIT_RETRY_WAIT);
+        CEvent::Sleep(CEC_DEFAULT_TRANSMIT_RETRY_WAIT);
       }
       bReturn = ADAPTER_MESSAGE_STATE_WAITING_TO_BE_SENT;
     }


### PR DESCRIPTION
This issue bugged me since a couple of month
See also Pulse-Eight/libcec#94
